### PR TITLE
fix: support `globalsPropValue: false` correctly

### DIFF
--- a/src/core/eslintrc.ts
+++ b/src/core/eslintrc.ts
@@ -13,7 +13,7 @@ export function generateESLintConfigs(
     .filter(Boolean)
     .sort()
     .forEach((name) => {
-      eslintConfigs.globals[name] = eslintrc.globalsPropValue || true
+      eslintConfigs.globals[name] = eslintrc.globalsPropValue
     })
   const jsonBody = JSON.stringify(eslintConfigs, null, 2)
   return jsonBody


### PR DESCRIPTION
`globalsPropValue` has already been normalized at

https://github.com/antfu/unplugin-auto-import/blob/c2a948fed90feceb100aedfbc3050e7947e1c28d/src/core/ctx.ts#L46

and current implementation does not support documented `false` value